### PR TITLE
Initial implementation of emitter example (no closed loop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono_examples"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.7",
+ "rand",
+ "rkyv",
+ "sequencer_common",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["sequencer_common", "sequencer_server", "unsequenced_producer", "iodaemon"]
+members = ["sequencer_common", "sequencer_server", "unsequenced_producer", "iodaemon", "chrono_examples"]

--- a/chrono_examples/Cargo.toml
+++ b/chrono_examples/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chrono_examples"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sequencer_common = { path = "../sequencer_common" }
+
+rkyv = { version = "0.7", features = ["validation", "size_32", "alloc"] }
+
+clap = { version = "3.1", features = ["derive", "env"] }
+rand = "0.8"

--- a/chrono_examples/src/bin/emitter.rs
+++ b/chrono_examples/src/bin/emitter.rs
@@ -1,0 +1,58 @@
+use std::net::{IpAddr, UdpSocket, SocketAddr};
+use std::pin::Pin;
+
+use clap::Parser;
+use rand::random;
+
+use sequencer_common::{ArchivedSequencerMessage, LengthTag, SequencerMessage};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long, env)]
+    ip_address: IpAddr,
+    #[clap(short, long, env)]
+    port: u16,
+    #[clap(short, long, env, value_parser = clap::value_parser!(u16).range(1..1500))]
+    size: u16,
+}
+
+pub fn main() -> std::io::Result<()> {
+    let args = Args::parse();
+    
+    // prepare port to send to sequencer
+    let socket = UdpSocket::bind("127.0.0.1:0")?;
+    socket.connect(SocketAddr::new(args.ip_address, args.port))?;
+    
+    // generate a random message payload
+    let payload :Vec<u8> = (0..args.size).map(|_| random()).collect();
+    let message = SequencerMessage::new(
+        random(),
+        random(),
+        random(),
+        0,
+        payload,
+    );
+    let mut message_bytes = rkyv::util::to_bytes::<_, 256>(&message).unwrap();
+    rkyv::check_archived_root::<SequencerMessage>(&message_bytes).unwrap();
+
+    loop {
+        let archived_message = unsafe { rkyv::archived_root_mut::<SequencerMessage>(Pin::new(&mut message_bytes)) };
+
+        let seqno = archived_message.app_sequence_number;
+        archived_message.modify_app_sequence_number(seqno + 1);
+        
+        socket.send(&message_bytes)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/sequencer_common/src/lib.rs
+++ b/sequencer_common/src/lib.rs
@@ -73,4 +73,16 @@ impl ArchivedSequencerMessage {
             Pin::new_unchecked(reference)
         }
     }
+
+    #[inline(always)]
+    // This is the pin projection from SequencerMessage -> app_sequence_number
+    pub fn modify_app_sequence_number(self: Pin<&mut Self>, value: u64) -> Pin<&mut Self> {
+        // Sequence number is not a reference type and does not contain any reference
+        // types, so this unsafe block *should* be good here.
+        unsafe {
+            let reference = self.get_unchecked_mut();
+            reference.app_sequence_number = value;
+            Pin::new_unchecked(reference)
+        }
+    }
 }


### PR DESCRIPTION
Quick implementation of an emitter test program which sprays fixed-size packets at the sequencer as quickly as it can.